### PR TITLE
new edge environments

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -30,6 +30,32 @@ production:
         safe: true
         consistency: strong
 
+edgeprod:
+  sessions:
+    default:
+      hosts:
+        - sayid.member1.mongohq.com:10001
+      username: <%= ENV['MONGOHQ_USER'] %>
+      password: <%= ENV['MONGOHQ_PASS'] %>
+      database: app10640640
+      options:
+        skip_version_check: true
+        safe: true
+        consistency: strong
+
+edgestage:
+  sessions:
+    default:
+      hosts:
+        - vincent.mongohq.com:10001
+      username: <%= ENV['MONGOHQ_USER'] %>
+      password: <%= ENV['MONGOHQ_PASS'] %>
+      database: app10640673
+      options:
+        skip_version_check: true
+        safe: true
+        consistency: strong
+
 staging:
   sessions:
     default:


### PR DESCRIPTION
Adding new config for the edge forums.  The plan is that stage and production will have their own forum instances, but that both of the lms instances, preview and live, in each environment will share a forum.

As context, the heroku env will contain the following:

MONGOHQ_USER=heroku
SEARCH_SERVER=http://8fbyb9cm:<REDACTED>@pepper-6356039.us-east-1.bonsai.io
MONGOHQ_PASS=REDACTED
RACK_ENV=edgestage
BONSAI_URL=http://8fbyb9cm:<REDACTED>@pepper-6356039.us-east-1.bonsai.io
NEW_RELIC_APP_NAME=comments-edge-stage
MONGOHQ_URL=mongodb://heroku:<REDACTED>@vincent.mongohq.com:10001/app10640673
API_KEY=<REDACTED DIFFERS PER ENVIRONMENT> 
