### PR TITLE
return group id in to_hash

### DIFF
--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -175,6 +175,7 @@ class CommentThread < Content
                             "votes" => votes.slice(*%w[count up_count down_count point]),
                             "tags" => tags_array,
                             "type" => "thread",
+                            "group_id" => group_id,
                             "endorsed" => endorsed?)
 
     if params[:recursive]


### PR DESCRIPTION
Need to return group id to the front end to display "this is visible to {group name}" messages.
