### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 ruby "1.9.3"
 
 gem 'pry'


### PR DESCRIPTION
update `source :rubygems` to `https://rubygems.org`.
makes it more secure.
makes warning go away.
