### PR TITLE
force moped v1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'yajl-ruby'
 gem 'ampex'
 
 gem 'mongo'
-gem 'moped'
+gem 'moped', "1.2.1"
 gem 'mongoid', "~> 3.0"
 gem 'bson_ext'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       moped (~> 1.1)
       origin (~> 1.0)
       tzinfo (~> 0.3.22)
-    moped (1.2.0)
+    moped (1.2.1)
     multi_json (1.3.6)
     newrelic_rpm (3.4.1)
     nokogiri (1.5.5)
@@ -172,7 +172,7 @@ DEPENDENCIES
   mongoid-tree!
   mongoid_magic_counter_cache!
   mongoid_taggable_with_context!
-  moped
+  moped (= 1.2.1)
   newrelic_rpm
   nokogiri
   pry


### PR DESCRIPTION
avoids Moped::Errors::OperationFailure "need to login" in edx loadtest environment

full changelog between v1.2.0 and v1.2.1 here: https://github.com/mongoid/moped/compare/v1.2.0...v1.2.1

all rspec tests pass, and 500 errors in loadtest go away.

@e0d @gwprice @kevinchugh 
