### PR TITLE
add "environment" settings, a more flexible "prod"

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -30,6 +30,21 @@ production:
         safe: true
         consistency: strong
 
+# configuration meant to be nearly the same as prod/stage, but to get
+# all it's configuration from the environment.
+parameterized:
+  sessions:
+    default:
+      hosts:
+        - <%= ENV['MONGO_HOST'] + ':' + ENV['MONGO_PORT'] %>
+      username: <%= ENV['MONGO_USER'] %>
+      password: <%= ENV['MONGO_PASS'] %>
+      database: <%= ENV['MONGO_DB'] %>
+      options:
+        skip_version_check: true
+        safe: true
+        consistency: strong
+
 edgeprod:
   sessions:
     default:

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -246,6 +246,11 @@ production:
   <<: *default_settings
   monitor_mode: true
 
+# the "parameterized" group should mirror production,
+parameterized:
+  <<: *default_settings
+  monitor_mode: true
+
 # Many applications have a staging environment which behaves
 # identically to production.  Support for that environment is provided
 # here.  By default, the staging environment has the agent turned on.


### PR DESCRIPTION
Instead of hardcoding database names and such into these config files, get them from the environment.  This should be more flexible.  This is what we're using for our production comment service at Stanford.

This is a bit of a hack, it seems like the right thing to do would be to parameterize the "production" setting itself so that edX.org database names weren't hardcoded in here, but without knowing the code/ops to do so I was unwilling to do that.  So just adding my own section.

@e0d, @kevinchugh or @jimabramson, can you code review please?  
