### PR TITLE
update to latest newrelic rpm

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       tzinfo (~> 0.3.22)
     moped (1.5.1)
     multi_json (1.3.6)
-    newrelic_rpm (3.4.1)
+    newrelic_rpm (3.6.8.164)
     nokogiri (1.5.5)
     origin (1.0.6)
     pry (0.9.10)


### PR DESCRIPTION
the latest version of the newrelic rpm gives us access to request queuing time in heroku, a datapoint which is otherwise hidden from us.

@e0d @gwprice 
