### PR TITLE
Allow authentication by HTTP header

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -61,7 +61,8 @@ DEFAULT_PER_PAGE = 20
 
 if RACK_ENV.to_s != "test" # disable api_key auth in test environment
   before do
-    error 401 unless params[:api_key] == CommentService.config[:api_key]
+    api_key = CommentService.config[:api_key]
+    error 401 unless params[:api_key] == api_key or env["HTTP_X_EDX_API_KEY"] == api_key
   end
 end
 


### PR DESCRIPTION
Previously, authentication could only be done using a URL parameter,
which appears in various logs. Now, clients can authenticate using a
more appropriate HTTP header.

@jimabramson @e0d
