### PR TITLE
less user queries

### DIFF
--- a/models/comment.rb
+++ b/models/comment.rb
@@ -3,7 +3,6 @@ require_relative 'content'
 class Comment < Content
 
   include Mongoid::Tree
-  include Mongo::Voteable
   include Mongoid::Timestamps
   include Mongoid::MagicCounterCache
   

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -2,7 +2,6 @@ require_relative 'content'
 
 class CommentThread < Content
 
-  include Mongo::Voteable
   include Mongoid::Timestamps
   include Mongoid::TaggableWithContext
   include Mongoid::TaggableWithContext::AggregationStrategy::RealTime

--- a/models/content.rb
+++ b/models/content.rb
@@ -1,6 +1,7 @@
 class Content
   
   include Mongoid::Document
+  include Mongo::Voteable
   
   field :visible, type: Boolean, default: true
   field :abuse_flaggers, type: Array, default: []

--- a/models/subscription.rb
+++ b/models/subscription.rb
@@ -9,6 +9,7 @@ class Subscription
   index({subscriber_id: 1, source_id: 1, source_type: 1})
   index({subscriber_id: 1, source_type: 1})
   index({subscriber_id: 1})
+  index({source_id: 1, source_type: 1}, {background: true})
 
   def to_hash
     as_document.slice(*%w[subscriber_id source_id source_type])

--- a/models/user.rb
+++ b/models/user.rb
@@ -23,47 +23,27 @@ class User
   validates_uniqueness_of :username
   validates_uniqueness_of :email
 
-  index external_id: 1
+  index( {external_id: 1}, {unique: true, background: true} )
 
   def subscriptions_as_source
     Subscription.where(source_id: id.to_s, source_type: self.class.to_s)
-  end
-
-  def subscriptions_as_subscriber
-    Subscription.where(subscriber_id: id.to_s)
   end
 
   def subscribed_thread_ids
     Subscription.where(subscriber_id: id.to_s, source_type: "CommentThread").only(:source_id).map(&:source_id)
   end
 
-  def subscribed_commentable_ids
-    subscriptions_as_subscriber.where(source_type: "Commentable").only(:source_id).map(&:source_id)
-  end
-
-  def subscribed_user_ids
-    subscriptions_as_subscriber.where(source_type: "User").only(:source_id).map(&:source_id)
-  end
-
   def subscribed_threads
     CommentThread.where(:id.in => subscribed_thread_ids)
-  end
-
-  def subscribed_commentables
-    Commentable.find(*subscribed_commentable_ids).only(:id).map(&:id)
-  end
-
-  def subscribed_users
-    subscribed_user_ids.map {|id| User.find(id)}
   end
 
   def to_hash(params={})
     hash = as_document.slice(*%w[username external_id])
     if params[:complete]
       hash = hash.merge("subscribed_thread_ids" => subscribed_thread_ids,
-                        "subscribed_commentable_ids" => subscribed_commentable_ids,
-                        "subscribed_user_ids" => subscribed_user_ids,
-                        "follower_ids" => subscriptions_as_source.only(:subscriber_id).map(&:subscriber_id),
+                        "subscribed_commentable_ids" => [], # not used by comment client.  To be removed once removed from comment client.
+                        "subscribed_user_ids" => [], # ditto.
+                        "follower_ids" => [], # ditto.
                         "id" => id,
                         "upvoted_ids" => upvoted_ids,
                         "downvoted_ids" => downvoted_ids,
@@ -81,11 +61,11 @@ class User
   end
 
   def upvoted_ids
-    Comment.up_voted_by(self).map(&:id) + CommentThread.up_voted_by(self).map(&:id)
+    Content.up_voted_by(self).map(&:id)
   end
 
   def downvoted_ids
-    Comment.down_voted_by(self).map(&:id) + CommentThread.down_voted_by(self).map(&:id)
+    Content.down_voted_by(self).map(&:id)
   end
 
   def followers
@@ -115,8 +95,6 @@ class User
   include ::NewRelic::Agent::MethodTracer
   add_method_tracer :to_hash
   add_method_tracer :subscribed_thread_ids
-  add_method_tracer :subscribed_commentable_ids
-  add_method_tracer :subscribed_user_ids
   add_method_tracer :upvoted_ids
   add_method_tracer :downvoted_ids
 

--- a/scripts/db/migrate-003-update-indexes.js
+++ b/scripts/db/migrate-003-update-indexes.js
@@ -1,0 +1,3 @@
+db.users.dropIndex({ external_id: 1 }) // drop the non-unique one
+db.users.ensureIndex({ external_id: 1 }, { unique: true, background: true })
+db.subscriptions.ensureIndex({ source_id: 1, source_type: 1 }, { background: true })

--- a/scripts/db/revert-migrate-003-update-indexes.js
+++ b/scripts/db/revert-migrate-003-update-indexes.js
@@ -1,0 +1,3 @@
+db.users.dropIndex({ external_id: 1 }) // drop the unique one
+db.users.ensureIndex({ external_id: 1 }, { background: true })
+db.subscriptions.dropIndex({ source_id: 1, source_type: 1 })


### PR DESCRIPTION
@gwprice @e0d 

the response time of the GET user endpoint should be reduced by at least 75%, based on a load test that's not quite finished running yet.
- added some newrelic instrumentation in User.to_hash.
- some queries' results are totally ignored by the comment client so they are removed.
- an index is used to speed up the 'subscribed thread ids' query (which previously did a fair bit of disk scans).
- index on users.external_id is now unique (did not test this in isolation - contribution to overall performance improvement may be negligible).
