### PR TITLE
Allow more endpoints to use commentable_ids param

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,5 @@ Christina Roberts <christina@edx.org>
 Calen Pennington <calen.pennington@gmail.com>
 Ed Zarecor <ed@edx.org>
 Jay Zoldak <jzoldak@edx.org>
+Jim Abramson <jsa@edx.org>
+Greg Price <gprice@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ These are notable changes in cs_comments_service.  This is a rolling list of cha
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+**api:** Add the ability to filter by commentable id to more endpoints
+  (in particular, /threads).
+
 **models:** added a new sorting key and index to `Comment` documents, removing the need
 for certain hierarchical db queries.  Also added a copy of the author's username 
 to `Comment` and `CommentThread` models, to reduce the number db queries.  

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -138,6 +138,10 @@ helpers do
       end
     end
 
+    if params[:commentable_ids]
+      comment_threads = comment_threads.in(commentable_id: params[:commentable_ids].split(","))
+    end
+
     sort_key_mapper = {
       "date" => :created_at,
       "activity" => :last_activity_at,

--- a/models/content.rb
+++ b/models/content.rb
@@ -14,6 +14,7 @@ class Content
 
   index({comment_thread_id: 1, sk: 1}, {sparse: true})
   index({comment_thread_id: 1, endorsed: 1}, {sparse: true})
+  index({commentable_id: 1}, {sparse: true, background: true})
 
   before_save :set_username
   def set_username

--- a/scripts/db/migrate-005-update-indexes.js
+++ b/scripts/db/migrate-005-update-indexes.js
@@ -1,0 +1,1 @@
+db.contents.ensureIndex({commentable_id: 1}, {sparse: true, background: true})

--- a/scripts/db/revert-migrate-005-update-indexes.js
+++ b/scripts/db/revert-migrate-005-update-indexes.js
@@ -1,0 +1,1 @@
+db.contents.dropIndex({commentable_id: 1})

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -26,6 +26,24 @@ describe "app" do
             res["course_id"].should == "abc"
           }
         end
+        it "returns only threads where course id and commentable id match" do
+          @threads["t1"].course_id = "course1"
+          @threads["t1"].commentable_id = "commentable1"
+          @threads["t1"].save!
+          @threads["t2"].course_id = "course1"
+          @threads["t2"].commentable_id = "commentable2"
+          @threads["t2"].save!
+          @threads["t3"].course_id = "course1"
+          @threads["t3"].commentable_id = "commentable3"
+          @threads["t3"].save!
+          @threads["t4"].course_id = "course2"
+          @threads["t4"].commentable_id = "commentable1"
+          @threads["t4"].save!
+          rs = thread_result course_id: "course1", commentable_ids: "commentable1,commentable3"
+          rs.length.should == 2
+          check_thread_result(nil, @threads["t3"], rs[0])
+          check_thread_result(nil, @threads["t1"], rs[1])
+        end
         it "returns only threads where course id and group id match" do
           @threads["t1"].course_id = "omg"
           @threads["t1"].group_id = 100


### PR DESCRIPTION
The commentable_ids param is a comma-delimited list of ids indicating
that only threads belonging to one of the specified commentables should
be returned. It can now be used by any endpoint that delegates to
handle_threads_query (most importantly "#{APIPREFIX}/threads"), and
the commentable_id field is now indexed for efficient filtering.

@jimabramson 
