### PR TITLE
optimize request timeout settings for heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,4 @@ end
 gem 'newrelic_rpm'
 gem 'newrelic_moped'
 gem 'unicorn'
+gem "rack-timeout"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
+    rack-timeout (0.0.4)
     raindrops (0.10.0)
     rake (0.9.2.2)
     rdiscount (1.6.8)
@@ -190,6 +191,7 @@ DEPENDENCIES
   pry
   pry-nav
   rack-test
+  rack-timeout
   rake
   rdiscount
   rest-client

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,7 @@
+require "rack-timeout"
+use Rack::Timeout           # Call as early as possible so rack-timeout runs before other middleware.
+Rack::Timeout.timeout = 20
+
 require './app'
 run Sinatra::Application
 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,3 @@
 worker_processes 4
-timeout 30
+timeout 25
 preload_app true


### PR DESCRIPTION
- use Rack::Timeout, set to 10s
- set unicorn timeout to 15s

per advice from Heroku support, this should both reduce the incidence/impact of dyno pileups, and should provide more visibility into the root causes of slowdowns.

in a preliminary loadtest (at 2x-3x peak prod load) there were still a few pileups, but we did indeed gain intelligible and useful error reporting in New Relic, so this should definitely help us narrow down our stability investigations.
