### PR TITLE
Fix Content-Type header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ These are notable changes in cs_comments_service.  This is a rolling list of cha
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.  Include a label indicating the component affected.
 
+**app.rb:** Return the correct Content-Type, application/json.
+
 **api:** Add the ability to filter by commentable id to more endpoints
   (in particular, /threads).
 

--- a/app.rb
+++ b/app.rb
@@ -66,6 +66,10 @@ if RACK_ENV.to_s != "test" # disable api_key auth in test environment
   end
 end
 
+before do
+  content_type "application/json"
+end
+
 if ENV["ENABLE_IDMAP_LOGGING"]
 
   after do

--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -4,6 +4,12 @@ describe "app" do
   describe "comments" do
     before(:each) { init_without_subscriptions }
     describe "GET /api/v1/comments/:comment_id" do
+      it "returns JSON" do
+        comment = Comment.first
+        get "/api/v1/comments/#{comment.id}"
+        last_response.should be_ok
+        last_response.content_type.should == "application/json;charset=utf-8"
+      end
       it "retrieve information of a single comment" do
         comment = Comment.first
         get "/api/v1/comments/#{comment.id}"

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -308,6 +308,13 @@ describe "app" do
 
       before(:each) { init_without_subscriptions }
       
+      it "returns JSON" do
+        thread = CommentThread.first
+        get "/api/v1/threads/#{thread.id}"
+        last_response.should be_ok
+        last_response.content_type.should == "application/json;charset=utf-8"
+      end
+
       it "get information of a single comment thread" do
         thread = CommentThread.first
         get "/api/v1/threads/#{thread.id}"


### PR DESCRIPTION
The default Content-Type is text/html, but all of our endpoints return
JSON, so Content-Type is now correctly set to application/json.

@jimabramson 
