### PR TITLE
disconnect default mongoid session after forking.

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,7 @@
 worker_processes 4
 timeout 25
 preload_app true
+
+after_fork do
+  ::Mongoid.default_session.disconnect
+end


### PR DESCRIPTION
@gwprice 

just confirmed in a load test that this gets rid of all of the mysterious mongoid/moped errors.
