### PR TITLE
use rack-timeout 0.1.0beta3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,4 @@ end
 gem 'newrelic_rpm'
 gem 'newrelic_moped'
 gem 'unicorn'
-gem "rack-timeout"
+gem "rack-timeout", "0.1.0beta3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
-    rack-timeout (0.0.4)
+    rack-timeout (0.1.0beta3)
     raindrops (0.10.0)
     rake (0.9.2.2)
     rdiscount (1.6.8)
@@ -191,7 +191,7 @@ DEPENDENCIES
   pry
   pry-nav
   rack-test
-  rack-timeout
+  rack-timeout (= 0.1.0beta3)
   rake
   rdiscount
   rest-client


### PR DESCRIPTION
@e0d @gwprice 

Per Heroku support: this "fixes some race conditions we've been seeing on unicorn web servers"
