### PR TITLE
use yajl for json serialization

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -114,6 +114,28 @@ end
 Mongoid.identity_map_enabled = true
 use Rack::Mongoid::Middleware::IdentityMap
 
+
+# use yajl implementation for to_json.
+# https://github.com/brianmario/yajl-ruby#json-gem-compatibility-api
+#
+# In addition to performance advantages over the standard JSON gem,
+# this avoids a bug with non-BMP characters.  For more info see:
+# https://github.com/rails/rails/issues/3727
+require 'yajl/json_gem'
+
+# patch json serialization of ObjectIds to work properly with yajl.
+# See https://groups.google.com/forum/#!topic/mongoid/MaXFVw7D_4s
+module Moped
+  module BSON
+    class ObjectId
+      def to_json
+        self.to_s.to_json
+      end
+    end
+  end
+end
+
+
 # these files must be required in order
 require './api/search'
 require './api/commentables'

--- a/spec/unicode_shared_examples.rb
+++ b/spec/unicode_shared_examples.rb
@@ -14,7 +14,6 @@ shared_examples "unicode data" do
   end
 
   it "can handle non-BMP data" do
-    pending("circumventing a bug in ActiveSupport's JSON encoding of non-BMP characters")
     test_unicode_data("𝕋𝕙𝕚𝕤 𝕡𝕠𝕤𝕥 𝕔𝕠𝕟𝕥𝕒𝕚𝕟𝕤 𝕔𝕙𝕒𝕣𝕒𝕔𝕥𝕖𝕣𝕤 𝕠𝕦𝕥𝕤𝕚𝕕𝕖 𝕥𝕙𝕖 𝔹𝕄ℙ")
   end
 


### PR DESCRIPTION
we've always had yajl in our Gemfile but to_json always fell back to the json gem (which in turn delegates to other implementations, such as ActiveSupport which has known bugs).

Yajl is not having any problems dealing with non-BMP unicode characters, and has the added benefits of being fast\* and not requiring any substantial code changes.

(*) http://japgolly.blogspot.com/2012/04/ruby-json-libraries.html

@gwprice 
