### PR TITLE
allow pagination of responses within thread views

### DIFF
--- a/api/search.rb
+++ b/api/search.rb
@@ -42,12 +42,12 @@ get "#{APIPREFIX}/search/threads" do
     if results.length == 0
       collection = []
     else
-      pres_threads = ThreadSearchResultPresenter.new(
+      pres_threads = ThreadSearchResultsPresenter.new(
         results,
         params[:user_id] ? user : nil,
         params[:course_id] || results.first.course_id
       )
-      collection = pres_threads.to_hash_array(bool_recursive)
+      collection = pres_threads.to_hash
     end
 
     num_pages = results.total_pages

--- a/api/users.rb
+++ b/api/users.rb
@@ -41,8 +41,8 @@ get "#{APIPREFIX}/users/:user_id/active_threads" do |user_id|
     paged_thread_ids.index(t.id)
   end
 
-  presenter = ThreadPresenter.new(paged_active_threads.to_a, user, params[:course_id])
-  collection = presenter.to_hash_array()
+  presenter = ThreadListPresenter.new(paged_active_threads.to_a, user, params[:course_id])
+  collection = presenter.to_hash
 
   json_output = nil
   self.class.trace_execution_scoped(['Custom/get_user_active_threads/json_serialize']) do

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -178,12 +178,12 @@ helpers do
       if threads.length == 0
         collection = []
       else
-        pres_threads = ThreadPresenter.new(
+        pres_threads = ThreadListPresenter.new(
           threads,
           params[:user_id] ? user : nil,
           params[:course_id] || threads.first.course_id
         )
-        collection = pres_threads.to_hash_array(bool_recursive)
+        collection = pres_threads.to_hash
       end
 
       json_output = nil

--- a/locale/en-US.yml
+++ b/locale/en-US.yml
@@ -5,4 +5,6 @@ en-US:
   value_is_required: "Value is required"
   value_is_invalid: "Value is invalid"
   anonymous: "anonymous"
-  blocked_content_with_body_hash: blocked content with body hash %{hash}
+  blocked_content_with_body_hash: "blocked content with body hash %{hash}"
+  param_must_be_a_non_negative_number: "%{param} must be a non-negative number"
+  param_must_be_a_number_greater_than_zero: "%{param} must be a number greater than zero"

--- a/presenters/thread_list.rb
+++ b/presenters/thread_list.rb
@@ -1,0 +1,21 @@
+require_relative 'thread'
+require_relative 'thread_utils'
+
+class ThreadListPresenter
+
+  def initialize(threads, user, course_id)
+    read_states = ThreadUtils.get_read_states(threads, user, course_id)
+    threads_endorsed = ThreadUtils.get_endorsed(threads)
+    @presenters = threads.map do |thread|
+      thread_key = thread._id.to_s
+      is_read, unread_count = read_states.fetch(thread_key, [false, thread.comment_count])
+      is_endorsed = threads_endorsed.fetch(thread_key, false)
+      ThreadPresenter.new(thread, user, is_read, unread_count, is_endorsed)
+    end
+  end
+
+  def to_hash
+    @presenters.map { |p| p.to_hash }
+  end
+
+end

--- a/presenters/thread_search_results.rb
+++ b/presenters/thread_search_results.rb
@@ -1,6 +1,6 @@
-require_relative 'thread'
+require_relative 'thread_list'
 
-class ThreadSearchResultPresenter < ThreadPresenter
+class ThreadSearchResultsPresenter < ThreadListPresenter
 
   alias :super_to_hash :to_hash
 
@@ -12,12 +12,13 @@ class ThreadSearchResultPresenter < ThreadPresenter
     super(threads, user, course_id)
   end
 
-  def to_hash(thread, with_comments=false)
-    thread_hash = super_to_hash(thread, with_comments)
-    highlight = @search_result_map[thread.id.to_s].highlight || {}
-    thread_hash["highlighted_body"] = (highlight[:body] || []).first || thread_hash["body"]
-    thread_hash["highlighted_title"] = (highlight[:title] || []).first || thread_hash["title"]
-    thread_hash
+  def to_hash
+    super_to_hash.each do |thread_hash|
+      thread_key = thread_hash['id'].to_s
+      highlight = @search_result_map[thread_key].highlight || {}
+      thread_hash["highlighted_body"] = (highlight[:body] || []).first || thread_hash["body"]
+      thread_hash["highlighted_title"] = (highlight[:title] || []).first || thread_hash["title"]
+    end
   end
 
 end

--- a/presenters/thread_utils.rb
+++ b/presenters/thread_utils.rb
@@ -1,0 +1,47 @@
+module ThreadUtils
+
+  def self.get_endorsed(threads)
+    # returns sparse hash {thread_key => true, ...}
+    # only threads which are endorsed will have entries, value will always be true.
+    endorsed_threads = {}
+    thread_ids = threads.collect {|t| t._id}
+    Comment.collection.aggregate(
+      {"$match" => {"comment_thread_id" => {"$in" => thread_ids}, "endorsed" => true}},
+      {"$group" => {"_id" => "$comment_thread_id"}}
+    ).each do |res| 
+      endorsed_threads[res["_id"].to_s] = true
+    end
+    endorsed_threads
+  end
+
+  def self.get_read_states(threads, user, course_id)
+    # returns sparse hash {thread_key => [is_read, unread_comment_count], ...}
+    read_states = {}
+    if user
+      read_dates = {}
+      read_state = user.read_states.where(:course_id => course_id).first
+      if read_state
+        read_dates = read_state["last_read_times"].to_hash
+        threads.each do |t|
+          thread_key = t._id.to_s
+          if read_dates.has_key? thread_key
+            is_read = read_dates[thread_key] >= t.updated_at
+            unread_comment_count = Comment.collection.where(
+              :comment_thread_id => t._id,
+              :author_id => {"$ne" => user.id},
+              :updated_at => {"$gte" => read_dates[thread_key]}
+              ).count
+            read_states[thread_key] = [is_read, unread_comment_count]
+          end
+        end
+      end
+    end
+    read_states
+  end
+
+  extend self
+    include ::NewRelic::Agent::MethodTracer
+    add_method_tracer :get_read_states
+    add_method_tracer :get_endorsed
+
+end

--- a/spec/api/commentable_spec.rb
+++ b/spec/api/commentable_spec.rb
@@ -25,26 +25,6 @@ describe "app" do
         threads.index{|c| c["body"] == "can anyone help me?"}.should_not be_nil
         threads.index{|c| c["body"] == "it is unsolvable"}.should_not be_nil
       end
-      it "get all comment threads and comments associated with a commentable object" do
-        get "/api/v1/question_1/threads", recursive: true
-        last_response.should be_ok
-        response = parse last_response.body
-        threads = response['collection']
-        threads.length.should == 2
-        threads.index{|c| c["body"] == "can anyone help me?"}.should_not be_nil
-        threads.index{|c| c["body"] == "it is unsolvable"}.should_not be_nil
-        thread = threads.select{|c| c["body"] == "can anyone help me?"}.first
-        children = thread["children"]
-        children.length.should == 2
-        children.index{|c| c["body"] == "this problem is so easy"}.should_not be_nil
-        children.index{|c| c["body"] =~ /^see the textbook/}.should_not be_nil
-        so_easy = children.select{|c| c["body"] == "this problem is so easy"}.first
-        so_easy["children"].length.should == 1
-        not_for_me = so_easy["children"].first
-        not_for_me["body"].should == "not for me!"
-        not_for_me["children"].length.should == 1
-        not_for_me["children"].first["body"].should == "not for me neither!"
-      end
       it "returns an empty array when the commentable object does not exist (no threads)" do
         get "/api/v1/does_not_exist/threads"
         last_response.should be_ok
@@ -57,11 +37,11 @@ describe "app" do
         commentable_id = "unicode_commentable"
         thread = make_thread(User.first, text, "unicode_course", commentable_id)
         make_comment(User.first, thread, text)
-        get "/api/v1/#{commentable_id}/threads", recursive: true
+        get "/api/v1/#{commentable_id}/threads"
         last_response.should be_ok
         result = parse(last_response.body)["collection"]
         result.should_not be_empty
-        check_thread_result(nil, thread, result.first, true)
+        check_thread_result_json(nil, thread, result.first)
       end
 
       include_examples "unicode data"

--- a/spec/api/query_spec.rb
+++ b/spec/api/query_spec.rb
@@ -18,7 +18,7 @@ describe "app" do
 				get "/api/v1/search/threads", text: random_string
 				last_response.should be_ok
 				threads = parse(last_response.body)['collection']
-				check_thread_result(nil, thread, threads.select{|t| t["id"] == thread.id.to_s}.first, false, true)
+				check_thread_result_json(nil, thread, threads.select{|t| t["id"] == thread.id.to_s}.first, true)
 			end
 
 		end
@@ -47,7 +47,7 @@ describe "app" do
 				get "/api/v1/search/threads", text: random_string
 				last_response.should be_ok
 				threads = parse(last_response.body)['collection']
-				check_thread_result(nil, thread, threads.select{|t| t["id"] == thread.id.to_s}.first, false, true)
+				check_thread_result_json(nil, thread, threads.select{|t| t["id"] == thread.id.to_s}.first, true)
 			end
 		end
 	end

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -16,11 +16,11 @@ describe "app" do
         # Elasticsearch does not necessarily make newly indexed content
         # available immediately, so we must explicitly refresh the index
         CommentThread.tire.index.refresh
-        get "/api/v1/search/threads", course_id: course_id, text: search_term, recursive: true
+        get "/api/v1/search/threads", course_id: course_id, text: search_term
         last_response.should be_ok
         result = parse(last_response.body)["collection"]
         result.length.should == 1
-        check_thread_result(nil, thread, result.first, true, true)
+        check_thread_result_json(nil, thread, result.first, true)
       end
 
       include_examples "unicode data"

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -69,8 +69,8 @@ describe "app" do
         @comments["t3 c4"].save!
         rs = thread_result 100, course_id: "xyz"
         rs.length.should == 2
-        check_thread_result(@users["u100"], @threads["t3"], rs[0], false)
-        check_thread_result(@users["u100"], @threads["t0"], rs[1], false)
+        check_thread_result_json(@users["u100"], @threads["t3"], rs[0])
+        check_thread_result_json(@users["u100"], @threads["t0"], rs[1])
       end
 
       it "does not return threads in which the user has only participated anonymously" do
@@ -79,7 +79,7 @@ describe "app" do
         @comments["t3 c4"].save!
         rs = thread_result 100, course_id: "xyz"
         rs.length.should == 1
-        check_thread_result(@users["u100"], @threads["t0"], rs.first, false)
+        check_thread_result_json(@users["u100"], @threads["t0"], rs.first)
       end      
 
       it "only returns threads from the specified course" do
@@ -164,7 +164,7 @@ describe "app" do
         make_comment(user, thread, text)
         result = thread_result(user.id, course_id: course_id)
         result.length.should == 1
-        check_thread_result(nil, thread, result.first)
+        check_thread_result_json(nil, thread, result.first)
       end
 
       include_examples "unicode data"

--- a/spec/presenters/thread_list_spec.rb
+++ b/spec/presenters/thread_list_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe ThreadListPresenter do
+  context "#initialize" do
+    before(:each) do
+      User.all.delete
+      Content.all.delete
+      @threads = (1..3).map do |n|
+        t = make_thread(
+          create_test_user("author#{n}"),
+          "thread #{n}",
+          'foo', 'bar'
+        )
+      end
+      @reader = create_test_user('reader')
+    end
+
+    it "handles unread threads" do
+      pres = ThreadListPresenter.new(@threads, @reader, 'foo')
+      pres.to_hash.each_with_index do |h, i|
+        h.should == ThreadPresenter.factory(@threads[i], @reader).to_hash
+      end
+    end
+
+    it "handles read threads" do
+      @reader.mark_as_read(@threads[0])
+      @reader.save!
+      pres = ThreadListPresenter.new(@threads, @reader, 'foo')
+      pres.to_hash.each_with_index do |h, i|
+        h.should == ThreadPresenter.factory(@threads[i], @reader).to_hash
+      end
+    end
+
+    it "handles empty list of threads" do
+      pres = ThreadListPresenter.new([], @reader, 'foo')
+      pres.to_hash.should == []
+    end
+
+  end
+end

--- a/spec/presenters/thread_search_result_spec.rb
+++ b/spec/presenters/thread_search_result_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ThreadSearchResultPresenter do
+describe ThreadSearchResultsPresenter do
   context "#to_hash" do
   
     before(:each) { setup_10_threads }
@@ -11,7 +11,7 @@ describe ThreadSearchResultPresenter do
       hash["highlighted_title"].should == ((search_result.highlight[:title] || []).first || hash["title"])
     end
 
-    def check_search_results_hash_array(search_results, hashes)
+    def check_search_results_hash(search_results, hashes)
       expected_order = search_results.map {|t| t.id}
       actual_order = hashes.map {|h| h["id"].to_s}
       actual_order.should == expected_order
@@ -23,8 +23,8 @@ describe ThreadSearchResultPresenter do
       mock_results = threads_random_order.map do |t| 
         double(Tire::Results::Item, :id => t._id.to_s, :highlight => {:body => ["foo"], :title => ["bar"]})
       end
-      pres = ThreadSearchResultPresenter.new(mock_results, nil, DFLT_COURSE_ID)
-      check_search_results_hash_array(mock_results, pres.to_hash_array)
+      pres = ThreadSearchResultsPresenter.new(mock_results, nil, DFLT_COURSE_ID)
+      check_search_results_hash(mock_results, pres.to_hash)
     end
 
     it "presents search results with correct default highlights" do
@@ -32,8 +32,8 @@ describe ThreadSearchResultPresenter do
       mock_results = threads_random_order.map do |t| 
         double(Tire::Results::Item, :id => t._id.to_s, :highlight => {})
       end
-      pres = ThreadSearchResultPresenter.new(mock_results, nil, DFLT_COURSE_ID)
-      check_search_results_hash_array(mock_results, pres.to_hash_array)
+      pres = ThreadSearchResultsPresenter.new(mock_results, nil, DFLT_COURSE_ID)
+      check_search_results_hash(mock_results, pres.to_hash)
     end
 
   end

--- a/spec/presenters/thread_spec.rb
+++ b/spec/presenters/thread_spec.rb
@@ -1,8 +1,117 @@
 require 'spec_helper'
 
 describe ThreadPresenter do
- context "#to_hash_array" do
   
+  context "#to_hash" do
+
+    before(:each) do 
+      User.all.delete
+      Content.all.delete
+
+      course_id, commentable_id = ['foo', 'bar']
+
+      @thread_no_responses = make_thread(
+        create_test_user('author1'),
+        'thread with no responses',
+        course_id, commentable_id
+      )
+
+      @thread_one_empty_response = make_thread(
+        create_test_user('author2'),
+        'thread with one response',
+        course_id, commentable_id
+      )
+      make_comment(create_test_user('author3'), @thread_one_empty_response, 'empty response')
+
+      @thread_one_response = make_thread(
+        create_test_user('author4'),
+        'thread with one response and some comments',
+        course_id, commentable_id
+      )
+      resp = make_comment(
+        create_test_user('author5'),
+        @thread_one_response,
+        'a response'
+      )
+      make_comment(create_test_user('author6'), resp, 'first comment')
+      make_comment(create_test_user('author7'), resp, 'second comment')
+      make_comment(create_test_user('author8'), resp, 'third comment')
+
+      @thread_ten_responses = make_thread(
+        create_test_user('author9'),
+        'thread with ten responses',
+        course_id, commentable_id
+      )
+      (1..10).each do |n|
+        resp = make_comment(create_test_user("author#{n+10}"), @thread_ten_responses, "response #{n}")
+        (1..3).each do |n2|
+          make_comment(create_test_user("author#{n+10}+#{n2}"), resp, "comment #{n+10}+#{n}")
+        end
+      end
+
+      @threads_with_num_comments = [
+        [@thread_no_responses, 0],
+        [@thread_one_empty_response, 1],
+        [@thread_one_response, 4],
+        [@thread_ten_responses, 40]
+      ]
+
+      @reader = create_test_user('thread reader')
+    end
+
+    it "handles with_responses=false" do
+      @threads_with_num_comments.each do |thread, num_comments|
+        hash = ThreadPresenter.new(thread, @reader, false, num_comments, false).to_hash
+        check_thread_result(@reader, thread, hash)
+        ['children', 'resp_skip', 'resp_limit', 'resp_total'].each {|k| (hash.has_key? k).should be_false }
+      end
+    end
+
+    it "handles with_responses=true" do
+      @threads_with_num_comments.each do |thread, num_comments|
+        hash = ThreadPresenter.new(thread, @reader, false, num_comments, false).to_hash true
+        check_thread_result(@reader, thread, hash)
+        check_thread_response_paging(thread, hash)
+      end
+    end
+
+    it "handles skip with no limit" do
+      @threads_with_num_comments.each do |thread, num_comments|
+        [0, 1, 2, 9, 10, 11, 1000].each do |skip|
+          hash = ThreadPresenter.new(thread, @reader, false, num_comments, false).to_hash true, skip
+          check_thread_result(@reader, thread, hash)
+          check_thread_response_paging(thread, hash, skip)
+        end
+      end
+    end
+
+    it "handles skip and limit" do
+      @threads_with_num_comments.each do |thread, num_comments|
+        [1, 2, 3, 9, 10, 11, 1000].each do |limit|
+          [0, 1, 2, 9, 10, 11, 1000].each do |skip|
+            hash = ThreadPresenter.new(thread, @reader, false, num_comments, false).to_hash true, skip, limit
+            check_thread_result(@reader, thread, hash)
+            check_thread_response_paging(thread, hash, skip, limit)
+          end
+        end
+      end
+    end
+
+    it "fails with invalid arguments" do
+      @threads_with_num_comments.each do |thread, num_comments|
+        [-1, true, "", nil].each do |skip|
+          expect{ThreadPresenter.new(thread, @reader, false, num_comments, false).to_hash true, 0, limit}.to raise_error
+        end
+        [-1, 0, true, "hello"].each do |limit|
+          expect{ThreadPresenter.new(thread, @reader, false, num_comments, false).to_hash true, 0, limit}.to raise_error
+        end
+      end
+    end
+
+  end
+
+  context "#merge_comments_recursive" do
+
     before(:each) { @cid_seq = 10 }
 
     def stub_each_from_array(obj, ary)
@@ -12,13 +121,20 @@ describe ThreadPresenter do
     end
 
     def set_comment_results(thread, ary)
+      # example usage:
+      # c0 = make_comment()
+      # c00 = make_comment(c0)
+      # c01 = make_comment(c0)
+      # c010 = make_comment(c01)
+      # set_comment_results(thread, [c0, c00, c01, c010])
+
       # avoids an unrelated expecation error
       thread.stub(:endorsed?).and_return(true)
       rs = stub_each_from_array(double("rs"), ary)
       criteria = double("criteria")
       criteria.stub(:order_by).and_return(rs)
       # stub Content, not Comment, because that's the model we will be querying against
-      Content.stub(:where).with(comment_thread_id: thread.id).and_return(criteria)
+      Content.stub(:where).with({"comment_thread_id" => thread.id}).and_return(criteria)
     end
 
     def make_comment(parent=nil)
@@ -30,17 +146,13 @@ describe ThreadPresenter do
     end
 
     it "nests comments in the correct order" do
-      thread = CommentThread.new
-      thread.id = 1
-      thread.author = User.new
-
       c0 = make_comment()
       c00 = make_comment(c0)
       c01 = make_comment(c0)
       c010 = make_comment(c01)
-      set_comment_results(thread, [c0, c00, c01, c010])
 
-      h = ThreadPresenter.new([thread], nil, thread.course_id).to_hash_array(true).first
+      pres = ThreadPresenter.new(nil, nil, nil, nil, nil)
+      h = pres.merge_comments_recursive({}, [c0, c00, c01, c010])
       h["children"].size.should == 1 # c0
       h["children"][0]["id"].should == c0.id
       h["children"][0]["children"].size.should == 2 # c00, c01
@@ -51,10 +163,6 @@ describe ThreadPresenter do
     end
 
     it "handles orphaned child comments gracefully" do
-      thread = CommentThread.new
-      thread.id = 33
-      thread.author = User.new
-
       c0 = make_comment()
       c00 = make_comment(c0)
       c000 = make_comment(c00)
@@ -64,9 +172,9 @@ describe ThreadPresenter do
       c111 = make_comment(c11)
       # lose c0 and c11 from result set.  their descendants should
       # be silently skipped over.
-      set_comment_results(thread, [c00, c000, c1, c10, c111])
 
-      h = ThreadPresenter.new([thread], nil, thread.course_id).to_hash_array(true).first
+      pres = ThreadPresenter.new(nil, nil, nil, nil, nil)
+      h = pres.merge_comments_recursive({}, [c00, c000, c1, c10, c111])
       h["children"].size.should == 1 # c1
       h["children"][0]["id"].should == c1.id
       h["children"][0]["children"].size.should == 1 # c10


### PR DESCRIPTION
@gwprice 

This implements resp_skip and resp_limit as optional parameters to `GET /api/v1/threads/:thread_id`.  They work only when `recursive=true` is also passed.  Things to note:
- the skip and limit values used are echoed back in the json view (even if they were not explicitly passed and defaults were used).   skip defaults to 0 and limit defaults to nil.
- though we discussed it previously, the total number of responses isn't passed back in the view.   we can add this, but i'd like to see if client-side logic will suffice for pagination controls (e.g. the client knows that no further responses are available once the server returns fewer results than the amount requested).
- using a comment depth (`level_limit`) other than 3 is not presently supported when using response windowing.  Behavior when the new parameters are not used is unchanged.
