### PR TITLE
send 404 instead of 500 when thread could not be found.

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -11,7 +11,11 @@ get "#{APIPREFIX}/threads" do # retrieve threads by course
 end
 
 get "#{APIPREFIX}/threads/:thread_id" do |thread_id|
-  thread = CommentThread.find(thread_id)
+  begin
+    thread = CommentThread.find(thread_id)
+  rescue Mongoid::Errors::DocumentNotFound
+    error 404, [t(:requested_object_not_found)].to_json
+  end
 
   if params["user_id"] and bool_mark_as_read
     user = User.only([:id, :username, :read_states]).find_by(external_id: params["user_id"])

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -375,12 +375,14 @@ describe "app" do
         check_thread_response_paging_json(thread, parse(last_response.body))
       end
 
-      it "returns 400 when the thread does not exist" do
-        get "/api/v1/threads/does_not_exist"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
-        get "/api/v1/threads/5016a3caec5eb9a12300000b1"
-        last_response.status.should == 400
+      it "returns 404 when the thread does not exist" do
+        thread = CommentThread.first
+        path = "/api/v1/threads/#{thread.id}"
+        get path
+        last_response.should be_ok
+        thread.destroy
+        get path
+        last_response.status.should == 404
         parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
       end
 


### PR DESCRIPTION
@gwprice 

low-priority tweak to handle thread-not-found with a standard 404.  corresponding PR in edx-platform to follow.
