### PR TITLE
use 404 when trying to GET a nonexistent user

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -13,7 +13,11 @@ post "#{APIPREFIX}/users" do
 end
 
 get "#{APIPREFIX}/users/:user_id" do |user_id|
-  user.to_hash(complete: bool_complete, course_id: params["course_id"]).to_json
+  begin
+    user.to_hash(complete: bool_complete, course_id: params["course_id"]).to_json
+  rescue Mongoid::Errors::DocumentNotFound
+    error 404
+  end
 end
 
 get "#{APIPREFIX}/users/:user_id/active_threads" do |user_id|

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -47,6 +47,20 @@ describe "app" do
         last_response.status.should == 400 
       end
     end
+    describe "GET /api/v1/users/:user_id" do
+      it "returns user information" do
+        get "/api/v1/users/1"
+        last_response.status.should == 200
+        res = parse(last_response.body)
+        user1 = User.find_by("1")
+        res["external_id"].should == user1.external_id
+        res["username"].should == user1.username
+      end
+      it "returns 404 if user does not exist" do
+        get "/api/v1/users/3"
+        last_response.status.should == 404
+      end
+    end
     describe "GET /api/v1/users/:user_id/active_threads" do
 
       before(:each) { setup_10_threads }


### PR DESCRIPTION
JIRA: FOR-522

This change enables the lms client to attempt graceful recovery when looking for a user that hasn't been synced yet, and is more correct HTTP behavior in the general sense.

@gwprice
