### PR TITLE
reinstate disconnection from mongo in unicorn master thread

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -5,3 +5,7 @@ preload_app true
 data_dir = ENV['DATA_DIR'] || Dir.tmpdir
 listen "unix:#{data_dir}/forum.sock", :backlog => 512
 pid "#{data_dir}/forum_unicorn.pid"
+
+after_fork do |server, worker|
+  ::Mongoid.default_session.disconnect
+end

--- a/config/unicorn_tcp.rb
+++ b/config/unicorn_tcp.rb
@@ -9,3 +9,7 @@ listen "#{listen_host}:#{listen_port}", :tcp_nopush => true, :backlog => 512
 
 data_dir = ENV['DATA_DIR'] || Dir.tmpdir
 pid "#{data_dir}/forum_unicorn.pid"
+
+after_fork do |server, worker|
+  ::Mongoid.default_session.disconnect
+end


### PR DESCRIPTION
https://github.com/edx/cs_comments_service/commit/e61430d9438abf1db64fcac0eb9dd3e0f18a07bd was inadvertently lost in a recent change, this puts it back.
