### PR TITLE
add create/update dates to comments index, for use in statistical facets

### DIFF
--- a/models/comment.rb
+++ b/models/comment.rb
@@ -33,8 +33,8 @@ class Comment < Content
   mapping do
     indexes :body, type: :string, analyzer: :english, stored: true, term_vector: :with_positions_offsets
     indexes :course_id, type: :string, index: :not_analyzed, included_in_all: false
-    #indexes :comment_thread_id, type: :string, stored: true, index: :not_analyzed, included_in_all: false
-    #current prod tire doesn't support indexing BSON ids, will reimplement when we upgrade
+    indexes :created_at, type: :date, included_in_all: false
+    indexes :updated_at, type: :date, included_in_all: false
   end
   
 


### PR DESCRIPTION
these are needed to work with index migration tooling (they only existed in the comment_threads index before, and need to be added here too)

@gwprice @e0d 
