### PR TITLE
add output to migrate-007, add script to revert it

### DIFF
--- a/scripts/db/migrate-007-thread-type.js
+++ b/scripts/db/migrate-007-thread-type.js
@@ -1,10 +1,19 @@
+var cnt = db.contents.find({_type: "CommentThread"}).count();
+var cnt_to_update = db.contents.find({_type: "CommentThread", thread_type: {$exists: false}}).count();
+print ("Updating " + cnt_to_update + " of " + cnt + " comment threads with default thread_type");
 db.contents.update(
     {_type: "CommentThread", thread_type: {$exists: false}},
     {$set: {thread_type: "discussion"}},
     {multi: true}
 );
+print ("done.\n");
+
+var cnt_to_update = db.contents.find({_type: "CommentThread", endorsed_response_count: {$exists: false}}).count();
+var cnt_updated = 0;
+var pct;
+print ("Updating " + cnt_to_update + " of " + cnt + " comment threads with endorsed_response_count");
 db.contents.find(
-    {_type: "CommentThread"},
+    {_type: "CommentThread", endorsed_response_count: {$exists: false}},
     {_id: 1}
 ).forEach(function(doc) {
     var endorsedCount = db.contents.find(
@@ -14,4 +23,10 @@ db.contents.find(
         {_id: doc._id},
         {$set: {endorsed_response_count: endorsedCount}}
     );
+    cnt_updated += 1;
+    if (cnt_updated % 100 == 0) {
+        pct = (cnt_updated / cnt_to_update) * 100;
+        print ("..." + cnt_updated + " of " + cnt_to_update + " completed (" + parseInt(pct) + "%)");
+    }
 });
+print ("done.\n");

--- a/scripts/db/revert-migrate-007-thread-type.js
+++ b/scripts/db/revert-migrate-007-thread-type.js
@@ -1,0 +1,9 @@
+var cnt = db.contents.find({_type: "CommentThread"}).count();
+print ("Removing thread_type and endorsed_response_count from " + cnt + " comment threads");
+db.contents.update(
+    {_type: "CommentThread"},
+    {$unset: {thread_type: "", endorsed_response_count: ""}},
+    {multi: true}
+);
+print ("done.\n");
+


### PR DESCRIPTION
@gwprice @e0d 

We need to re-run this in the test environment since it didn't exit cleanly, and we also need to see how it impacts normal traffic / performance (observed 5-10% locking while it was running).

These changes just add console output to the main migration, and a script we can use to revert the migration and re-run it.

One minor change to the migration, in addition, it will skip any threads whose `endorsed_response_count` has already been set.
