### PR TITLE
SQUASH ME: revert to on-demand computation of thread endorsement

### DIFF
--- a/models/comment.rb
+++ b/models/comment.rb
@@ -28,14 +28,6 @@ class Comment < Content
     end
   end
 
-  before_update :update_thread
-  def update_thread()
-    if self.endorsed_changed?
-      delta = self.endorsed ? 1 : -1
-      self.comment_thread.inc(:endorsed_response_count, delta)
-    end
-  end
-
   include Tire::Model::Search
   include Tire::Model::Callbacks
 

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -11,7 +11,6 @@ class CommentThread < Content
 
   enumerize :thread_type, in: [:question, :discussion]
   field :comment_count, type: Integer, default: 0
-  field :endorsed_response_count, type: Integer, default: 0
   field :title, type: String
   field :body, type: String
   field :course_id, type: String
@@ -112,8 +111,12 @@ class CommentThread < Content
     subscriptions.map(&:subscriber)
   end
 
+  def endorsed?
+    comments.where(endorsed: true).exists?
+  end
+
   def to_hash(params={})
-    as_document.slice(*%w[thread_type title body endorsed_response_count course_id anonymous anonymous_to_peers commentable_id created_at updated_at at_position_list closed])
+    as_document.slice(*%w[thread_type title body course_id anonymous anonymous_to_peers commentable_id created_at updated_at at_position_list closed])
                      .merge("id" => _id, "user_id" => author_id,
                             "username" => author_username,
                             "votes" => votes.slice(*%w[count up_count down_count point]),

--- a/presenters/thread.rb
+++ b/presenters/thread.rb
@@ -9,16 +9,18 @@ class ThreadPresenter
     course_id = thread.course_id
     thread_key = thread._id.to_s
     is_read, unread_count = ThreadUtils.get_read_states([thread], user, course_id).fetch(thread_key, [false, thread.comment_count])
-    self.new thread, user, is_read, unread_count
+    is_endorsed = ThreadUtils.get_endorsed([thread]).fetch(thread_key, false)
+    self.new thread, user, is_read, unread_count, is_endorsed
   end
 
-  def initialize(thread, user, is_read, unread_count)
+  def initialize(thread, user, is_read, unread_count, is_endorsed)
     # generally not intended for direct use.  instantiated by self.factory or
     # by thread list presenters.
     @thread = thread
     @user = user
     @is_read = is_read
     @unread_count = unread_count
+    @is_endorsed = is_endorsed
   end
 
   def to_hash with_responses=false, resp_skip=0, resp_limit=nil
@@ -27,7 +29,7 @@ class ThreadPresenter
     h = @thread.to_hash
     h["read"] = @is_read
     h["unread_comments_count"] = @unread_count
-    h["endorsed"] = @thread.endorsed_response_count > 0
+    h["endorsed"] = @is_endorsed || false
     if with_responses
       if @thread.thread_type.discussion? && resp_skip == 0 && resp_limit.nil?
         content = Comment.where(comment_thread_id: @thread._id).order_by({"sk" => 1})

--- a/presenters/thread_list.rb
+++ b/presenters/thread_list.rb
@@ -5,10 +5,12 @@ class ThreadListPresenter
 
   def initialize(threads, user, course_id)
     read_states = ThreadUtils.get_read_states(threads, user, course_id)
+    threads_endorsed = ThreadUtils.get_endorsed(threads)
     @presenters = threads.map do |thread|
       thread_key = thread._id.to_s
       is_read, unread_count = read_states.fetch(thread_key, [false, thread.comment_count])
-      ThreadPresenter.new(thread, user, is_read, unread_count)
+      is_endorsed = threads_endorsed.fetch(thread_key, false)
+      ThreadPresenter.new(thread, user, is_read, unread_count, is_endorsed)
     end
   end
 

--- a/presenters/thread_utils.rb
+++ b/presenters/thread_utils.rb
@@ -1,5 +1,19 @@
 module ThreadUtils
 
+  def self.get_endorsed(threads)
+    # returns sparse hash {thread_key => true, ...}
+    # only threads which are endorsed will have entries, value will always be true.
+    endorsed_threads = {}
+    thread_ids = threads.collect {|t| t._id}
+    Comment.collection.aggregate(
+      {"$match" => {"comment_thread_id" => {"$in" => thread_ids}, "endorsed" => true}},
+      {"$group" => {"_id" => "$comment_thread_id"}}
+    ).each do |res| 
+      endorsed_threads[res["_id"].to_s] = true
+    end
+    endorsed_threads
+  end
+
   def self.get_read_states(threads, user, course_id)
     # returns sparse hash {thread_key => [is_read, unread_comment_count], ...}
     read_states = {}
@@ -28,5 +42,6 @@ module ThreadUtils
   extend self
     include ::NewRelic::Agent::MethodTracer
     add_method_tracer :get_read_states
+    add_method_tracer :get_endorsed
 
 end

--- a/scripts/db/migrate-007-thread-type.js
+++ b/scripts/db/migrate-007-thread-type.js
@@ -1,17 +1,9 @@
+var cnt = db.contents.find({_type: "CommentThread"}).count();
+var cnt_to_update = db.contents.find({_type: "CommentThread", thread_type: {$exists: false}}).count();
+print ("Updating " + cnt_to_update + " of " + cnt + " comment threads with default thread_type");
 db.contents.update(
     {_type: "CommentThread", thread_type: {$exists: false}},
     {$set: {thread_type: "discussion"}},
     {multi: true}
 );
-db.contents.find(
-    {_type: "CommentThread"},
-    {_id: 1}
-).forEach(function(doc) {
-    var endorsedCount = db.contents.find(
-        {comment_thread_id: doc._id, parent_id: {$exists: false}, endorsed: true}
-    ).count();
-    db.contents.update(
-        {_id: doc._id},
-        {$set: {endorsed_response_count: endorsedCount}}
-    );
-});
+print ("done.\n");

--- a/scripts/db/revert-migrate-007-thread-type.js
+++ b/scripts/db/revert-migrate-007-thread-type.js
@@ -1,0 +1,8 @@
+var cnt = db.contents.find({_type: "CommentThread", thread_type: {$exists: true}}).count();
+print ("Removing thread_type from " + cnt + " comment threads");
+db.contents.update(
+    {_type: "CommentThread"},
+    {$unset: {thread_type: ""}},
+    {multi: true}
+);
+print ("done.\n");

--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -66,13 +66,11 @@ describe "app" do
         comment.endorsement.should_not be_nil
         comment.endorsement["user_id"].should == "#{User.first.id}"
         comment.endorsement["time"].should be_between(before, after)
-        comment.comment_thread.endorsed_response_count.should == 1
         put "/api/v1/comments/#{comment.id}", endorsed: false_val
         last_response.should be_ok
         comment.reload
         comment.endorsed.should == false
         comment.endorsement.should be_nil
-        comment.comment_thread.endorsed_response_count.should == 0
       end
       it "updates endorsed correctly" do
         test_update_endorsed(true, false)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -17,15 +17,4 @@ describe Comment do
   end
 
   include_examples "unicode data"
-
-  it "should update its thread when endorsed changes" do
-    comment = make_comment(author, thread, "dummy")
-    orig_count = thread.endorsed_response_count
-    comment.endorsed = true
-    comment.save!
-    thread.endorsed_response_count.should == orig_count + 1
-    comment.endorsed = false
-    comment.save!
-    thread.endorsed_response_count.should == orig_count
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -208,7 +208,7 @@ def check_thread_result(user, thread, hash, is_json=false)
   expected_keys = %w(id thread_type title body course_id commentable_id created_at updated_at)
   expected_keys += %w(anonymous anonymous_to_peers at_position_list closed user_id)
   expected_keys += %w(username votes abuse_flaggers tags type group_id pinned)
-  expected_keys += %w(comments_count unread_comments_count read endorsed endorsed_response_count)
+  expected_keys += %w(comments_count unread_comments_count read endorsed)
   # these keys are checked separately, when desired, using check_thread_response_paging.
   actual_keys = hash.keys - [
     "children", "endorsed_responses", "non_endorsed_responses", "resp_skip",
@@ -235,8 +235,7 @@ def check_thread_result(user, thread, hash, is_json=false)
   hash["type"].should == "thread"
   hash["group_id"].should == thread.group_id
   hash["pinned"].should == thread.pinned?
-  hash["endorsed"].should == thread.endorsed_response_count > 0
-  hash["endorsed_response_count"].should == thread.endorsed_response_count
+  hash["endorsed"].should == thread.endorsed?
   hash["comments_count"].should == thread.comments.length
 
   if is_json
@@ -321,7 +320,6 @@ def check_question_response_paging(thread, hash, resp_skip=0, resp_limit=nil, is
   all_responses = thread.root_comments.sort({"sk" => 1}).to_a
   endorsed_responses, non_endorsed_responses = all_responses.partition { |resp| resp.endorsed }
 
-  hash["endorsed_response_count"] == endorsed_responses.length
   hash["endorsed_responses"].length.should == endorsed_responses.length
   hash["endorsed_responses"].each_with_index do |response_hash, i|
     check_comment(endorsed_responses[i], response_hash, is_json)


### PR DESCRIPTION
@gwprice @e0d 

per discussions today.  reinstates previous thread endorsement computation, and simplifies migrations.

once merged, this commit should be squashed into greg's last commit on the thread-type branch.
