### PR TITLE
Add validation for undo_vote_for to avoid a crash

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -63,7 +63,9 @@ helpers do
 
   def undo_vote_for(obj)
     raise ArgumentError, t(:user_id_is_required) unless user
-    user.unvote(obj)
+    if user.voted?(obj)
+      user.unvote(obj)
+    end
     obj.reload.to_hash.to_json
   end
   


### PR DESCRIPTION
This PR add a validation in undo_vote_for to avoid the following crash:

```
NoMethodError - undefined method `-@' for nil:NilClass:
        /edx/app/forum/.gem/bundler/gems/voteable_mongo-538e86856daa/lib/voteable_mongo/voting.rb:145:in `unvote_query_and_update'
        /edx/app/forum/.gem/bundler/gems/voteable_mongo-538e86856daa/lib/voteable_mongo/voting.rb:25:in `vote'
        /edx/app/forum/.gem/bundler/gems/voteable_mongo-538e86856daa/lib/voteable_mongo/voteable.rb:137:in `vote'
        /edx/app/forum/.gem/bundler/gems/voteable_mongo-538e86856daa/lib/voteable_mongo/voter.rb:87:in `vote'
        /edx/app/forum/.gem/bundler/gems/voteable_mongo-538e86856daa/lib/voteable_mongo/voter.rb:55:in `unvote'
        /edx/app/forum/cs_comments_service/lib/helpers.rb:66:in `undo_vote_for'
        /edx/app/forum/cs_comments_service/api/votes.rb:14:in `block in <top (required)>'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:1264:in `call'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:1264:in `block in compile!'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:835:in `[]'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:835:in `block (3 levels) in route!'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:851:in `route_eval'
        /edx/app/forum/.gem/gems/newrelic_rpm-3.6.8.164/lib/new_relic/agent/instrumentation/sinatra.rb:133:in `route_eval_with_newrelic'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:835:in `block (2 levels) in route!'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:872:in `block in process_route'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:870:in `catch'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:870:in `process_route'
        /edx/app/forum/.gem/gems/newrelic_rpm-3.6.8.164/lib/new_relic/agent/instrumentation/sinatra.rb:116:in `process_route_with_newrelic'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:834:in `block in route!'
        /edx/app/forum/.gem/gems/sinatra-1.3.3/lib/sinatra/base.rb:833:in `each'
.......
```

Reported by a client, in a inline discussion, it happens sometime that a user click very fast on the vote/unvote button. Due to some connection/network delay, the unvote call might arrive first to the server and makes it crash. Basically, the unvote call will always crash if there were no upvote before for the user. This PR fixes the issue by adding a simple check. 
