### PR TITLE
api to get total and active posts for a course

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Jim Abramson <jsa@edx.org>
 Greg Price <gprice@edx.org>
 Sarina Canelake <sarina@edx.org>
 Alexandre Dubus <alexandre.dubus@inria.fr>
+Zia Fazal <zfazal@edx.org>

--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -82,3 +82,15 @@ delete "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   thread.destroy
   thread.to_hash.to_json
 end
+
+get "#{APIPREFIX}/courses/*/stats"  do |course_id| # retrieve stats by course
+  begin
+    threads = Content.where(_type: "CommentThread", course_id: course_id)
+    active_threads = threads.where(:last_activity_at.gte => 1.day.ago)
+    course_stats = {
+      "num_threads" => threads.count,
+      "num_active_threads" => active_threads.count
+    }
+    course_stats.to_json
+  end
+end


### PR DESCRIPTION
@gwprice @jimabramson @sarina there is a requirement on api end of edx-solutions to get count of total post and active posts. I have added these apis to support that please review.
