### PR TITLE
Dan f/upgrade travis mongo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ language: ruby
 rvm:
   - "1.9.3"
 services:
-  - mongodb
   - elasticsearch
 before_install:
   - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.11.deb && sudo dpkg --force-confnew -i elasticsearch-0.90.11.deb && sudo service elasticsearch restart
+  # Install mongo 2.6.4 according to http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
+  # TODO: This won't be necessary when travis switches to 2.6 by default - see https://github.com/travis-ci/travis-ci/issues/2246
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-get update -q
+  - sudo apt-get install -y mongodb-org=2.6.4 mongodb-org-server=2.6.4 mongodb-org-shell=2.6.4 mongodb-org-mongos=2.6.4 mongodb-org-tools=2.6.4
+  - mongo --version
 script: bundle exec rspec


### PR DESCRIPTION
Use mongo 2.6.4 in our Travis builds.

@jimabramson please review.
@feanil FYI.
